### PR TITLE
chore: Minor dependencies upgrade

### DIFF
--- a/modules/flags/src/test/scala/pillars/flags/FlagManagerTests.scala
+++ b/modules/flags/src/test/scala/pillars/flags/FlagManagerTests.scala
@@ -37,9 +37,12 @@ class FlagManagerTests extends CatsEffectSuite:
                 manager <- FlagManagerLoader().createManager[IO](config)
                 enabled <- manager.isEnabled(flag)
             yield enabled
-        assertIO(isEnabled(flag"flag1"), true)
-        assertIO(isEnabled(flag"flag2"), false)
-        assertIO(isEnabled(flag"undefined"), false)
+        for
+            _ <- assertIO(isEnabled(flag"flag1"), true)
+            _ <- assertIO(isEnabled(flag"flag2"), false)
+            _ <- assertIO(isEnabled(flag"undefined"), false)
+        yield ()
+        end for
 
     test("FlagManager should perform the action if flag is enabled"):
         given Tracer[IO] = Tracer.noop[IO]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.3",
-      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.3",
+      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.3",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.8.0",
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-client"         % "1.10.4" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     )
 
     val http4sClient: Seq[ModuleID] = Seq(
-      "org.http4s" %% "http4s-netty-client" % "0.5.15"
+      "org.http4s" %% "http4s-netty-client" % "0.5.16"
     )
     val http4sServer: Seq[ModuleID] = Seq(
       "org.http4s" %% "http4s-netty-server" % "0.5.15"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
 
     val observability: Seq[ModuleID] = Seq(
       "org.typelevel"   %% "otel4s-java"                               % "0.4.0",
-      "io.opentelemetry" % "opentelemetry-exporter-otlp"               % "1.36.0" % Runtime,
+      "io.opentelemetry" % "opentelemetry-exporter-otlp"               % "1.37.0" % Runtime,
       "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "1.36.0" % Runtime
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,7 @@ object Dependencies {
 
     val migrationsRuntime: Seq[ModuleID] = Seq(
       "org.postgresql" % "postgresql"                 % "42.7.3",
-      "org.flywaydb"   % "flyway-database-postgresql" % "10.10.0"
+      "org.flywaydb"   % "flyway-database-postgresql" % "10.11.0"
     )
     val migrations: Seq[ModuleID]        = Seq(
       "org.flywaydb" % "flyway-core" % "10.11.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.4",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.8.0",
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-client"         % "1.10.4" % Test,
-      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.10.3" % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.10.4" % Test,
       "com.softwaremill.sttp.client3" %% "core"                        % "3.9.5"  % Test
       //    "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle" % "1.9.1",
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
       "org.http4s" %% "http4s-netty-client" % "0.5.16"
     )
     val http4sServer: Seq[ModuleID] = Seq(
-      "org.http4s" %% "http4s-netty-server" % "0.5.15"
+      "org.http4s" %% "http4s-netty-server" % "0.5.16"
     )
     val scodec: Seq[ModuleID]       = Seq(
       "org.scodec" %% "scodec-bits" % "2.2.2",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,7 +101,7 @@ object Dependencies {
       "org.flywaydb"   % "flyway-database-postgresql" % "10.10.0"
     )
     val migrations: Seq[ModuleID]        = Seq(
-      "org.flywaydb" % "flyway-core" % "10.10.0"
+      "org.flywaydb" % "flyway-core" % "10.11.0"
     ) ++ tests ++ testContainers ++ migrationsRuntime.map(_ % Test)
 
     val fs2Rabbit: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.3",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.8.0",
-      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-client"         % "1.10.3" % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-client"         % "1.10.4" % Test,
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.10.3" % Test,
       "com.softwaremill.sttp.client3" %% "core"                        % "3.9.5"  % Test
       //    "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle" % "1.9.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
     )
 
     private val tapir = Seq(
-      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.10.3",
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.3",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
     val observability: Seq[ModuleID] = Seq(
       "org.typelevel"   %% "otel4s-java"                               % "0.4.0",
       "io.opentelemetry" % "opentelemetry-exporter-otlp"               % "1.37.0" % Runtime,
-      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "1.36.0" % Runtime
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "1.37.0" % Runtime
     )
 
     val database: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
 
     private val tapir = Seq(
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.10.4",
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.3",
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.3",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.4",
-      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.3",
+      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.4",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.8.0",
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-client"         % "1.10.4" % Test,
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.10.3" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
     private val tapir = Seq(
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.10.4",
-      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.3",
+      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.10.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.10.4",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.8.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
-addSbtPlugin("org.typelevel"       % "sbt-tpolecat"     % "0.5.0")
+addSbtPlugin("org.typelevel"       % "sbt-tpolecat"     % "0.5.1")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.5.2")
 
 // Cross compilation


### PR DESCRIPTION
Updates:

* 📦 [com.softwaremill.sttp.tapir:tapir-http4s-client](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-http4s-server](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-iron](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-json-circe](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-openapi-docs](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-opentelemetry-metrics](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [com.softwaremill.sttp.tapir:tapir-sttp-stub-server](https://github.com/softwaremill/tapir) from 1.10.3 to 1.10.4
  * 📜 [GitHub Release Notes](https://github.com/softwaremill/tapir/releases/tag/v1.10.4) - [Version Diff](https://github.com/softwaremill/tapir/compare/v1.10.3...v1.10.4)
* 📦 [io.opentelemetry:opentelemetry-exporter-otlp](https://github.com/open-telemetry/opentelemetry-java) from 1.36.0 to 1.37.0
  * 📜 [GitHub Release Notes](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.37.0) - [Version Diff](https://github.com/open-telemetry/opentelemetry-java/compare/v1.36.0...v1.37.0)
* 📦 [io.opentelemetry:opentelemetry-sdk-extension-autoconfigure](https://github.com/open-telemetry/opentelemetry-java) from 1.36.0 to 1.37.0
  * 📜 [GitHub Release Notes](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.37.0) - [Version Diff](https://github.com/open-telemetry/opentelemetry-java/compare/v1.36.0...v1.37.0)
* 📦 [org.flywaydb:flyway-core](https://github.com/flyway/flyway) from 10.10.0 to 10.11.0
* 📦 [org.flywaydb:flyway-database-postgresql](https://github.com/flyway/flyway) from 10.10.0 to 10.11.0
* 📦 [org.http4s:http4s-netty-client](https://github.com/http4s/http4s-netty) from 0.5.15 to 0.5.16
  * 📜 [GitHub Release Notes](https://github.com/http4s/http4s-netty/releases/tag/v0.5.16) - [Version Diff](https://github.com/http4s/http4s-netty/compare/v0.5.15...v0.5.16)
* 📦 [org.http4s:http4s-netty-server](https://github.com/http4s/http4s-netty) from 0.5.15 to 0.5.16
  * 📜 [GitHub Release Notes](https://github.com/http4s/http4s-netty/releases/tag/v0.5.16) - [Version Diff](https://github.com/http4s/http4s-netty/compare/v0.5.15...v0.5.16)
* 📦 [org.typelevel:sbt-tpolecat](https://github.com/typelevel/sbt-tpolecat) from 0.5.0 to 0.5.1
  * 📜 [GitHub Release Notes](https://github.com/typelevel/sbt-tpolecat/releases/tag/v0.5.1) - [Version Diff](https://github.com/typelevel/sbt-tpolecat/compare/v0.5.0...v0.5.1)