### PR TITLE
feat(core): Errors are returned in json

### DIFF
--- a/modules/core/src/main/scala/pillars/PillarsError.scala
+++ b/modules/core/src/main/scala/pillars/PillarsError.scala
@@ -45,6 +45,14 @@ object PillarsError:
         override def details: Option[String] = Some(reason.getMessage)
     end Unknown
 
+    private[pillars] final case class PayloadTooLarge(maxLength: Long) extends PillarsError:
+        override def code: Code              = Code("ERR")
+        override def number: ErrorNumber     = ErrorNumber(Int.MaxValue)
+        override def message: Message        = Message(s"Payload limit ($maxLength) exceeded".refineUnsafe)
+        override def status: StatusCode      = StatusCode.PayloadTooLarge
+        override def details: Option[String] = Some(s"Payload limit ($maxLength) exceeded")
+    end PayloadTooLarge
+
     private type CodeConstraint = (Not[Empty] & LettersUpperCase) DescribedAs "Code cannot be empty"
     opaque type Code <: String  = String :| CodeConstraint
 

--- a/modules/example/src/main/rest/app.http
+++ b/modules/example/src/main/rest/app.http
@@ -1,8 +1,32 @@
 @host = http://localhost:9876
 
 ###
-# @name home
-GET {{ host }}/
+# @name ping
+GET {{ host }}/ping
+
+> {%
+  client.test("Request executed successfully", function () {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+
+  client.test("Request returned the correct body", function () {
+    client.assert(response.body === "pong", "Response body is not pong");
+  });
+%}
+
+###
+# @name boom
+GET {{ host }}/boom
+
+> {%
+  client.test("Request failed successfully 🙂", function () {
+    client.assert(response.status === 500, "Response status is not 500");
+  });
+
+  client.test("Request returned json", function () {
+    client.assert(response.contentType === "application/json", "Response is not in json format");
+  });
+%}
 
 ###
 # @name user list

--- a/modules/example/src/main/scala/example/Endpoints.scala
+++ b/modules/example/src/main/scala/example/Endpoints.scala
@@ -8,10 +8,25 @@ import sttp.tapir.codec.iron.given
 import sttp.tapir.json.circe.jsonBody
 
 object Endpoints:
-    val home: Endpoint[Unit, Unit, Unit, String, Any] = endpoint.get.out(stringBody)
+    private val base                                               = endpoint.errorOut(jsonBody[PillarsError.View])
+    val ping: Endpoint[Unit, Unit, PillarsError.View, String, Any] =
+        base
+            .get
+            .in("ping")
+            .name("ping")
+            .description("Always return pong")
+            .out(stringBody)
 
-    private val base     = endpoint.in("v0").errorOut(jsonBody[PillarsError.View])
-    private val userBase = base.in("user")
+    val boom: Endpoint[Unit, Unit, PillarsError.View, String, Any] =
+        base
+            .get
+            .in("boom")
+            .name("boom")
+            .description("Always in error")
+            .out(stringBody)
+
+    private val api      = endpoint.in("v0").errorOut(jsonBody[PillarsError.View])
+    private val userBase = api.in("user")
 
     val createUser: Endpoint[Unit, UserView, PillarsError.View, UserView, Any] = userBase
         .in(jsonBody[UserView])
@@ -37,7 +52,7 @@ object Endpoints:
         .name("delete user")
 
     val all = List(
-      home,
+      ping,
       createUser,
       listUser,
       getUser,

--- a/modules/example/src/main/scala/example/controllers.scala
+++ b/modules/example/src/main/scala/example/controllers.scala
@@ -7,9 +7,11 @@ import pillars.Controller.HttpEndpoint
 import pillars.Pillars
 
 final case class HomeController()(using Pillars[IO]) extends Controller[IO]:
-    def list: HttpEndpoint[IO] = Endpoints.home.serverLogicSuccess: _ =>
-        "👋 Hi".pure[IO]
-    val endpoints              = List(list)
+    def ping: HttpEndpoint[IO] = Endpoints.ping.serverLogicSuccess: _ =>
+        "pong".pure[IO]
+    def boom: HttpEndpoint[IO] = Endpoints.boom.serverLogic: _ =>
+        throw new RuntimeException("💣 boom")
+    val endpoints              = List(ping, boom)
 end HomeController
 
 final case class UserController()(using Pillars[IO]) extends Controller[IO]:


### PR DESCRIPTION
In API, errors are returned as JSON.

Returned format is 

```json
{
	"code": "API-XXXX",
	"message": "error summary",
	"details": "detailled message",
}
```

In case of an uncatched exception, if the exception extends `PillarsError`, the response will be the JSON serialization of the exception.  Else, the message will be `Internal Server Error` and the `details` will contain the message of the exception (result of `Throwable.getMessage`)
