### PR TITLE
:bug: Use ssl parameter from config for DB session

### DIFF
--- a/modules/db-skunk/src/main/scala/pillars/db/db.scala
+++ b/modules/db-skunk/src/main/scala/pillars/db/db.scala
@@ -74,7 +74,8 @@ class DBLoader extends Loader:
                          queryCache = config.queryCache,
                          parseCache = config.parseCache,
                          readTimeout = config.readTimeout,
-                         redactionStrategy = config.redactionStrategy
+                         redactionStrategy = config.redactionStrategy,
+                         ssl = config.ssl
                        )
             _       <- Resource.eval(logger.info("DB module loaded"))
         yield DB(poolRes)


### PR DESCRIPTION
## Describe the changes
The ssl parameter from the configuration was not taken into account when creating a skunk pooled session.

## Related issues
Please link any related issues here.

## Checklist
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional context
Add any other context or screenshots about the pull request here.
