### PR TITLE
166 allow using multiple rabbitmq hosts

### DIFF
--- a/.better-commits.json
+++ b/.better-commits.json
@@ -105,12 +105,12 @@
                 "label": "http-client"
             },
             {
-                "value": "rabbitmq-client",
-                "label": "rabbitmq-client"
+                "value": "rabbitmq",
+                "label": "rabbitmq"
             },
             {
-                "value": "redis-client",
-                "label": "redis-client"
+                "value": "redis",
+                "label": "redis"
             },
             {
                 "value": "",

--- a/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
+++ b/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
@@ -32,8 +32,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.language.postfixOps
 
-extension [F[_]](p: Pillars[F])
-    def rabbit: RabbitMQ[F] = p.module[RabbitMQ[F]](RabbitMQ.Key)
+def rabbit[F[_]](using p: Pillars[F]): RabbitMQ[F] = p.module[RabbitMQ[F]](RabbitMQ.Key)
 
 final case class RabbitMQ[F[_]: Async](config: RabbitMQConfig, client: RabbitClient[F]) extends Module[F]:
     override type ModuleConfig = RabbitMQConfig

--- a/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
+++ b/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
@@ -1,5 +1,6 @@
 package pillars.rabbitmq.fs2
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import com.comcast.ip4s.*
 import com.dimafeng.testcontainers.RabbitMQContainer
@@ -39,8 +40,12 @@ class RabbitMQTests extends CatsEffectSuite, TestContainerForEach:
     given Tracer[IO] = Tracer.noop[IO]
 
     private def configFor(container: RabbitMQContainer): RabbitMQConfig = RabbitMQConfig(
-      host = Host.fromString(container.host).get,
-      port = Port.fromInt(container.container.getMappedPort(5672)).get
+      nodes = NonEmptyList.one(
+        RabbitMQConfig.Node(
+          host = Host.fromString(container.host).get,
+          port = Port.fromInt(container.container.getMappedPort(5672)).get
+        )
+      )
     )
 
     test("allow exchanging messages"):


### PR DESCRIPTION
- **docs: update CHANGELOG.md for v0.3.8 [skip ci]**
- **feat(rabbitmq-client): #166 Allow usage of multiple RabbitMQ nodes**
