### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
       description: |
         examples:
           - **JVM**: Oracle GraalVM 21.0.2
-          - **Scala**: 3.3.3
+          - **Scala**: 3.3.4
           - **Pillars**: 0.2.22
       value: |
         - **JVM**:

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,6 +10,8 @@ reviewers = [ "rlemaitre" ]
 
 updates.ignore = [
   { groupId = "io.circe", artifactId = "circe-yaml-v12", version = "1.15.0" },
-  { groupId = "io.circe", artifactId = "circe-yaml", version = "1.15.0" }
+  { groupId = "io.circe", artifactId = "circe-yaml", version = "1.15.0" },
+  { groupId = "org.tpolecat", artifactId = "skunk-core", version = "1.1.0-M3" },
+  { groupId = "org.tpolecat", artifactId = "skunk-circe", version = "1.1.0-M3" }
 ]
 

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,3 +3,4 @@ rules = [
 ]
 
 OrganizeImports.removeUnused = true
+OrganizeImports.targetDialect = Scala3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 java         oracle-graalvm-21.0.2
 sbt          1.10.1
 doctoolchain 3.2.0
+scala        3.5.2

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.typelevel.scalacoptions.ScalacOptions
 import org.typelevel.scalacoptions.ScalaVersion
 
 ThisBuild / versionScheme          := Some("semver-spec")
-ThisBuild / scalaVersion           := "3.3.4"
+ThisBuild / scalaVersion           := "3.5.2"
 ThisBuild / organization           := "com.rlemaitre"
 ThisBuild / homepage               := Some(url("https://pillars.dev/"))
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
@@ -30,7 +30,7 @@ ThisBuild / licenses += (
   )
 )
 ThisBuild / scalacOptions ++= ScalacOptions.tokensForVersion(
-  ScalaVersion.V3_3_0,
+  ScalaVersion.V3_5_0,
   Set(
     ScalacOptions.deprecation,
     ScalacOptions.feature,
@@ -41,7 +41,7 @@ ThisBuild / scalacOptions ++= ScalacOptions.tokensForVersion(
 //javaOptions += "-Dotel.java.global-autoconfigure.enabled=true"
 
 Compile / scalacOptions ++= ScalacOptions.tokensForVersion(
-  ScalaVersion.V3_3_0,
+  ScalaVersion.V3_5_0,
   Set(
     ScalacOptions.sourceFuture,
     ScalacOptions.deprecation,
@@ -59,6 +59,10 @@ outputStrategy := Some(StdoutOutput)
 //libraryDependencySchemes ++= Seq(
 //  "org.typelevel" %% "otel4s-core-trace" % VersionScheme.Always
 //)
+val libDependencySchemes = Seq(
+  "io.circe"      %% "circe-yaml"        % VersionScheme.Always,
+  "org.typelevel" %% "otel4s-core-trace" % VersionScheme.Always
+)
 
 lazy val core = Project("pillars-core", file("modules/core"))
     .enablePlugins(BuildInfoPlugin)
@@ -67,18 +71,19 @@ lazy val core = Project("pillars-core", file("modules/core"))
       description      := "pillars-core is a scala 3 library providing base services for writing backend applications",
       libraryDependencies ++= Dependencies.core,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.build"
+      buildInfoPackage := "pillars.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
 
 lazy val dbSkunk = Project("pillars-db-skunk", file("modules/db-skunk"))
     .enablePlugins(BuildInfoPlugin)
     .settings(
-      name                                        := "pillars-db-skunk",
-      description                                 := "pillars-db-skunk is a scala 3 library providing database services for writing backend applications using skunk",
+      name             := "pillars-db-skunk",
+      description      := "pillars-db-skunk is a scala 3 library providing database services for writing backend applications using skunk",
       libraryDependencies ++= Dependencies.skunk,
-      buildInfoKeys                               := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage                            := "pillars.db.build",
-      libraryDependencySchemes += "org.typelevel" %% "otel4s-core-trace" % VersionScheme.Always
+      buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
+      buildInfoPackage := "pillars.db.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -89,7 +94,8 @@ lazy val dbDoobie = Project("pillars-db-doobie", file("modules/db-doobie"))
       description      := "pillars-db-doobie is a scala 3 library providing database services for writing backend applications using doobie",
       libraryDependencies ++= Dependencies.doobie,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.doobie.build"
+      buildInfoPackage := "pillars.doobie.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -100,7 +106,8 @@ lazy val redisRediculous = Project("pillars-redis-rediculous", file("modules/red
       description      := "pillars-redis-rediculous is a scala 3 library providing redis services for writing backend applications using rediculous",
       libraryDependencies ++= Dependencies.rediculous,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.doobie.build"
+      buildInfoPackage := "pillars.doobie.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -112,7 +119,8 @@ lazy val dbMigrations = Project("pillars-db-migration", file("modules/db-migrati
       libraryDependencySchemes += "org.typelevel" %% "otel4s-core-trace" % VersionScheme.Always,
       libraryDependencies ++= Dependencies.migrations,
       buildInfoKeys                               := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage                            := "pillars.db.migrations.build"
+      buildInfoPackage                            := "pillars.db.migrations.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core, dbSkunk)
 
@@ -123,7 +131,8 @@ lazy val rabbitmqFs2 = Project("pillars-rabbitmq-fs2", file("modules/rabbitmq-fs
       description      := "pillars-rabbitmq-fs2 is a scala 3 library providing RabbitMQ services for writing backend applications using fs2-rabbit",
       libraryDependencies ++= Dependencies.fs2Rabbit,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.rabbitmq.fs2.build"
+      buildInfoPackage := "pillars.rabbitmq.fs2.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -134,7 +143,8 @@ lazy val flags = Project("pillars-flags", file("modules/flags"))
       description      := "pillars-flag is a scala 3 library providing feature flag services for writing backend applications",
       libraryDependencies ++= Dependencies.flags,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.flags.build"
+      buildInfoPackage := "pillars.flags.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -145,7 +155,8 @@ lazy val httpClient = Project("pillars-http-client", file("modules/http-client")
       description      := "pillars-http-client is a scala 3 library providing http client services for writing backend applications",
       libraryDependencies ++= Dependencies.httpClient,
       buildInfoKeys    := Seq[BuildInfoKey](name, version, description),
-      buildInfoPackage := "pillars.httpclient.build"
+      buildInfoPackage := "pillars.httpclient.build",
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 
@@ -153,21 +164,22 @@ lazy val httpClient = Project("pillars-http-client", file("modules/http-client")
 lazy val example = Project("pillars-example", file("modules/example"))
     .enablePlugins(BuildInfoPlugin) // //<1>
     .settings(
-      name                                        := "pillars-example", // //<2>
-      description                                 := "pillars-example is an example of application using pillars", // //<3>
+      name             := "pillars-example",                                            // //<2>
+      description      := "pillars-example is an example of application using pillars", // //<3>
       libraryDependencies ++= Dependencies.tests ++ Dependencies.migrationsRuntime,
-      buildInfoKeys                               := Seq[BuildInfoKey](name, version, description), // //<4>
-      buildInfoOptions                            := Seq(BuildInfoOption.Traits("pillars.BuildInfo")), // //<5>
-      buildInfoPackage                            := "example.build", // //<6>
-      publish / skip                              := true,
-      libraryDependencySchemes += "org.typelevel" %% "otel4s-core-trace" % VersionScheme.Always
+      buildInfoKeys    := Seq[BuildInfoKey](name, version, description),                // //<4>
+      buildInfoOptions := Seq(BuildInfoOption.Traits("pillars.BuildInfo")),             // //<5>
+      buildInfoPackage := "example.build",                                              // //<6>
+      publish / skip   := true,
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core, dbSkunk, flags, httpClient, dbMigrations)
 // end::example[]
 lazy val docs = Project("pillars-docs", file("modules/docs"))
     .settings(
       name           := "pillars-docs",
-      publish / skip := true
+      publish / skip := true,
+      libraryDependencySchemes ++= libDependencySchemes
     )
     .dependsOn(core)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.typelevel.scalacoptions.ScalacOptions
 import org.typelevel.scalacoptions.ScalaVersion
 
 ThisBuild / versionScheme          := Some("semver-spec")
-ThisBuild / scalaVersion           := "3.3.3"
+ThisBuild / scalaVersion           := "3.3.4"
 ThisBuild / organization           := "com.rlemaitre"
 ThisBuild / homepage               := Some(url("https://pillars.dev/"))
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"

--- a/modules/core/src/main/scala/pillars/AdminServer.scala
+++ b/modules/core/src/main/scala/pillars/AdminServer.scala
@@ -8,7 +8,6 @@ import com.comcast.ip4s.*
 import io.circe.Codec
 import io.circe.derivation.Configuration
 import pillars.AdminServer.Config
-import pillars.PillarsError.View
 import sttp.tapir.*
 
 final case class AdminServer[F[_]: Async](

--- a/modules/core/src/main/scala/pillars/HttpServer.scala
+++ b/modules/core/src/main/scala/pillars/HttpServer.scala
@@ -90,7 +90,7 @@ object HttpServer:
         new ExceptionHandler[F]:
             override def apply(ctx: ExceptionContext)(implicit
                 monad: MonadError[F]
-            ): F[Option[ValuedEndpointOutput[_]]] =
+            ): F[Option[ValuedEndpointOutput[?]]] =
                 def handlePillarsError(e: PillarsError) =
                     Some(ValuedEndpointOutput(statusCode.and(jsonBody[PillarsError.View]), (e.status, e.view)))
 

--- a/modules/core/src/main/scala/pillars/Metrics.scala
+++ b/modules/core/src/main/scala/pillars/Metrics.scala
@@ -21,7 +21,7 @@ import sttp.tapir.server.metrics.Metric
 import sttp.tapir.server.metrics.MetricLabels
 import sttp.tapir.server.model.ServerResponse
 
-case class Metrics[F[_]: Applicative](meter: Meter[F], metrics: List[Metric[F, _]]):
+case class Metrics[F[_]: Applicative](meter: Meter[F], metrics: List[Metric[F, ?]]):
     /** The interceptor which can be added to a server's options, to enable metrics collection. */
     def metricsInterceptor(ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty): MetricsRequestInterceptor[F] =
         new MetricsRequestInterceptor[F](metrics, ignoreEndpoints)
@@ -75,9 +75,9 @@ object Metrics:
             duration     <- requestDuration(meter)
             requestSize  <- requestBodySize(meter)
             responseSize <- responseBodySize(meter)
-        yield Metrics(meter, List[Metric[F, _]](active, total, duration))
+        yield Metrics(meter, List[Metric[F, ?]](active, total, duration))
 
-    def init[F[_]: Applicative](meter: Meter[F], metrics: List[Metric[F, _]]): F[Metrics[F]] =
+    def init[F[_]: Applicative](meter: Meter[F], metrics: List[Metric[F, ?]]): F[Metrics[F]] =
         Metrics(meter, metrics).pure[F]
 
     def noop[F[_]: Applicative]: Metrics[F] = Metrics(Meter.noop[F], Nil)

--- a/modules/example/src/main/resources/config.yaml
+++ b/modules/example/src/main/resources/config.yaml
@@ -2,7 +2,7 @@
 name: Bookstore
 # tag::log[]
 log:
-  level: info
+  level: debug
   format: enhanced
   output:
     type: console

--- a/modules/flags/src/test/scala/pillars/flags/FeatureFlagTests.scala
+++ b/modules/flags/src/test/scala/pillars/flags/FeatureFlagTests.scala
@@ -1,6 +1,5 @@
 package pillars.flags
 
-import io.circe.Decoder
 import io.circe.Decoder.Result
 import io.circe.Json
 import io.circe.syntax.*

--- a/modules/http-client/src/main/scala/pillars/httpclient/httpclient.scala
+++ b/modules/http-client/src/main/scala/pillars/httpclient/httpclient.scala
@@ -105,7 +105,7 @@ final case class HttpClient[F[_]: Async](config: HttpClient.Config)(client: org.
         callRequest(endpoint, uri)(interpreter.toSecureRequest(endpoint, uri)(securityInput)(input))
     end callSecure
 
-    private[this] def callRequest[I, EO, O](
+    private def callRequest[I, EO, O](
         endpoint: AnyEndpoint,
         uri: Option[Uri],
         handler: FailureHandler[F, EO, O] = FailureHandler.default[F, EO, O]
@@ -166,7 +166,7 @@ object HttpClient:
             extends Error(endpoint, uri, ErrorNumber(1002), Message("Missing"))
         case Multiple[R](endpoint: AnyEndpoint, uri: Option[Uri], vs: Seq[R])
             extends Error(endpoint, uri, ErrorNumber(1003), Message("Multiple response"))
-        case InvalidInput(endpoint: AnyEndpoint, uri: Option[Uri], errors: List[ValidationError[_]])
+        case InvalidInput(endpoint: AnyEndpoint, uri: Option[Uri], errors: List[ValidationError[?]])
             extends Error(endpoint, uri, ErrorNumber(1004), Message("Invalid input"))
         case Mismatch(endpoint: AnyEndpoint, uri: Option[Uri], expected: String, actual: String)
             extends Error(endpoint, uri, ErrorNumber(1005), Message("Type mismatch"))

--- a/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
+++ b/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
@@ -89,6 +89,7 @@ case class RabbitMQConfig(
     internalQueueSize: Option[Int :| Positive] = Some(1024),
     requestedHeartbeat: FiniteDuration = 60 seconds,
     automaticRecovery: Boolean = true,
+    automaticTopologyRecovery: Boolean = true,
     clientProvidedConnectionName: Option[RabbitMQConnectionName] = None
 ) extends pillars.Config
 
@@ -112,6 +113,7 @@ object RabbitMQConfig:
           internalQueueSize = cfg.internalQueueSize,
           requestedHeartbeat = cfg.requestedHeartbeat,
           automaticRecovery = cfg.automaticRecovery,
+          automaticTopologyRecovery = cfg.automaticTopologyRecovery,
           clientProvidedConnectionName = cfg.clientProvidedConnectionName
         )
 end RabbitMQConfig

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.7",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
-      "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.7" % Test,
       "com.softwaremill.sttp.client3" %% "core"                        % "3.10.1" % Test
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
 
     val http4sClient: Seq[ModuleID] = Seq(
       "org.http4s"                  %% "http4s-netty-client" % "0.5.19",
-      "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.11.4",
+      "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.11.7",
       "com.alejandrohdezma"         %% "http4s-munit"        % "1.1.0" % Test
     )
     val http4sServer: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
 
     val http4s: Seq[ModuleID] = Seq(
       "org.http4s" %% "http4s-core"  % "0.23.29",
-      "org.http4s" %% "http4s-dsl"   % "0.23.28",
+      "org.http4s" %% "http4s-dsl"   % "0.23.29",
       "org.http4s" %% "http4s-circe" % "0.23.29"
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.7",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.4" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,7 +97,7 @@ object Dependencies {
 
     val migrationsRuntime: Seq[ModuleID] = Seq(
       "org.postgresql" % "postgresql"                 % "42.7.4",
-      "org.flywaydb"   % "flyway-database-postgresql" % "10.18.0"
+      "org.flywaydb"   % "flyway-database-postgresql" % "10.18.2"
     )
     val migrations: Seq[ModuleID]        = Seq(
       "org.flywaydb" % "flyway-core" % "10.18.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,7 +100,7 @@ object Dependencies {
       "org.flywaydb"   % "flyway-database-postgresql" % "10.18.0"
     )
     val migrations: Seq[ModuleID]        = Seq(
-      "org.flywaydb" % "flyway-core" % "10.18.0"
+      "org.flywaydb" % "flyway-core" % "10.18.2"
     ) ++ tests ++ testContainers ++ migrationsRuntime.map(_ % Test)
 
     val fs2Rabbit: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
 
     private val tapir = Seq(
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
       "org.typelevel" %% "cats-core"             % "2.12.0",
       "org.typelevel" %% "cats-effect"           % "3.5.4",
       "co.fs2"        %% "fs2-core"              % "3.11.0",
-      "org.typelevel" %% "cats-collections-core" % "0.9.8",
+      "org.typelevel" %% "cats-collections-core" % "0.9.9",
       "org.typelevel" %% "cats-time"             % "0.5.1"
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
     )
 
     val logging: Seq[ModuleID] = Seq( //
-      "com.outr" %% "scribe"            % "3.15.0",
+      "com.outr" %% "scribe"            % "3.15.2",
       "com.outr" %% "scribe-cats"       % "3.15.0",
       "com.outr" %% "scribe-slf4j"      % "3.15.0",
       "com.outr" %% "scribe-json-circe" % "3.15.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     )
 
     val http4sClient: Seq[ModuleID] = Seq(
-      "org.http4s"                  %% "http4s-netty-client" % "0.5.19",
+      "org.http4s"                  %% "http4s-netty-client" % "0.5.20",
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.11.7",
       "com.alejandrohdezma"         %% "http4s-munit"        % "1.1.0" % Test
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,9 @@
 import sbt.*
+
 object Dependencies {
     val effect: Seq[ModuleID] = Seq(
       "org.typelevel" %% "cats-core"             % "2.12.0",
-      "org.typelevel" %% "cats-effect"           % "3.5.5",
+      "org.typelevel" %% "cats-effect"           % "3.5.6",
       "co.fs2"        %% "fs2-core"              % "3.11.0",
       "org.typelevel" %% "cats-collections-core" % "0.9.9",
       "org.typelevel" %% "cats-time"             % "0.5.1"
@@ -25,7 +26,7 @@ object Dependencies {
       "io.circe" %% "circe-core"    % "0.14.10",
       "io.circe" %% "circe-generic" % "0.14.10",
       "io.circe" %% "circe-parser"  % "0.14.10",
-      "io.circe" %% "circe-yaml"    % "0.15.3"
+      "io.circe" %% "circe-yaml"    % "0.16.0"
     )
 
     val http4s: Seq[ModuleID] = Seq(
@@ -35,27 +36,27 @@ object Dependencies {
     )
 
     val http4sClient: Seq[ModuleID] = Seq(
-      "org.http4s"                  %% "http4s-netty-client" % "0.5.20",
-      "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.11.7",
+      "org.http4s"                  %% "http4s-netty-client" % "0.5.21",
+      "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.11.9",
       "com.alejandrohdezma"         %% "http4s-munit"        % "1.1.0" % Test
     )
     val http4sServer: Seq[ModuleID] = Seq(
-      "org.http4s" %% "http4s-netty-server" % "0.5.20"
+      "org.http4s" %% "http4s-netty-server" % "0.5.21"
     )
     val scodec: Seq[ModuleID]       = Seq(
       "org.scodec" %% "scodec-bits" % "2.2.2",
-      "org.scodec" %% "scodec-core" % "2.2.2"
+      "org.scodec" %% "scodec-core" % "2.3.2"
     )
 
     private val tapir = Seq(
-      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.7",
-      "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
-      "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.7" % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.9",
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.9",
+      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.9",
+      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.9",
+      "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.9",
+      "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3" exclude ("io.circe", "circe-yaml"),
+      "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.9",
+      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.9" % Test,
       "com.softwaremill.sttp.client3" %% "core"                        % "3.10.1" % Test
     )
 
@@ -81,13 +82,13 @@ object Dependencies {
     )
 
     val observability: Seq[ModuleID] = Seq(
-      "org.typelevel" %% "otel4s-sdk"          % "0.8.1",
-      "org.typelevel" %% "otel4s-sdk-exporter" % "0.8.1"
+      "org.typelevel" %% "otel4s-sdk"          % "0.11.1",
+      "org.typelevel" %% "otel4s-sdk-exporter" % "0.11.1"
     )
 
     val skunk: Seq[ModuleID] = Seq(
-      "org.tpolecat" %% "skunk-core"  % "1.0.0-M7" exclude ("org.typelevel", "otel4s-core-trace"),
-      "org.tpolecat" %% "skunk-circe" % "1.0.0-M7"
+      "org.tpolecat" %% "skunk-core"  % "1.0.0-M8",
+      "org.tpolecat" %% "skunk-circe" % "1.0.0-M8"
     ) ++ tests
 
     val doobie: Seq[ModuleID] = Seq(
@@ -97,10 +98,10 @@ object Dependencies {
 
     val migrationsRuntime: Seq[ModuleID] = Seq(
       "org.postgresql" % "postgresql"                 % "42.7.4",
-      "org.flywaydb"   % "flyway-database-postgresql" % "10.18.2"
+      "org.flywaydb"   % "flyway-database-postgresql" % "11.0.0"
     )
     val migrations: Seq[ModuleID]        = Seq(
-      "org.flywaydb" % "flyway-core" % "10.18.2"
+      "org.flywaydb" % "flyway-core" % "11.0.0"
     ) ++ tests ++ testContainers ++ migrationsRuntime.map(_ % Test)
 
     val fs2Rabbit: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
     val http4s: Seq[ModuleID] = Seq(
       "org.http4s" %% "http4s-core"  % "0.23.28",
       "org.http4s" %% "http4s-dsl"   % "0.23.28",
-      "org.http4s" %% "http4s-circe" % "0.23.28"
+      "org.http4s" %% "http4s-circe" % "0.23.29"
     )
 
     val http4sClient: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.7",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.4",
-      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.4" % Test,
+      "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.7" % Test,
       "com.softwaremill.sttp.client3" %% "core"                        % "3.10.1" % Test
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
       "com.outr" %% "scribe"            % "3.15.2",
       "com.outr" %% "scribe-cats"       % "3.15.2",
       "com.outr" %% "scribe-slf4j"      % "3.15.0",
-      "com.outr" %% "scribe-json-circe" % "3.15.0",
+      "com.outr" %% "scribe-json-circe" % "3.15.2",
       "com.outr" %% "scribe-file"       % "3.15.2"
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     private val tapir = Seq(
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.7",
-      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.7",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
     )
 
     val http4s: Seq[ModuleID] = Seq(
-      "org.http4s" %% "http4s-core"  % "0.23.28",
+      "org.http4s" %% "http4s-core"  % "0.23.29",
       "org.http4s" %% "http4s-dsl"   % "0.23.28",
       "org.http4s" %% "http4s-circe" % "0.23.29"
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,7 @@ object Dependencies {
 
     val logging: Seq[ModuleID] = Seq( //
       "com.outr" %% "scribe"            % "3.15.2",
-      "com.outr" %% "scribe-cats"       % "3.15.0",
+      "com.outr" %% "scribe-cats"       % "3.15.2",
       "com.outr" %% "scribe-slf4j"      % "3.15.0",
       "com.outr" %% "scribe-json-circe" % "3.15.0",
       "com.outr" %% "scribe-file"       % "3.15.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
     )
 
     private val tapir = Seq(
-      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
       "com.alejandrohdezma"         %% "http4s-munit"        % "1.1.0" % Test
     )
     val http4sServer: Seq[ModuleID] = Seq(
-      "org.http4s" %% "http4s-netty-server" % "0.5.19"
+      "org.http4s" %% "http4s-netty-server" % "0.5.20"
     )
     val scodec: Seq[ModuleID]       = Seq(
       "org.scodec" %% "scodec-bits" % "2.2.2",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 object Dependencies {
     val effect: Seq[ModuleID] = Seq(
       "org.typelevel" %% "cats-core"             % "2.12.0",
-      "org.typelevel" %% "cats-effect"           % "3.5.4",
+      "org.typelevel" %% "cats-effect"           % "3.5.5",
       "co.fs2"        %% "fs2-core"              % "3.11.0",
       "org.typelevel" %% "cats-collections-core" % "0.9.9",
       "org.typelevel" %% "cats-time"             % "0.5.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
       "com.outr" %% "scribe-cats"       % "3.15.2",
       "com.outr" %% "scribe-slf4j"      % "3.15.0",
       "com.outr" %% "scribe-json-circe" % "3.15.0",
-      "com.outr" %% "scribe-file"       % "3.15.0"
+      "com.outr" %% "scribe-file"       % "3.15.2"
     )
 
     val tests: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"      % "1.11.4" % Test,
-      "com.softwaremill.sttp.client3" %% "core"                        % "3.9.8"  % Test
+      "com.softwaremill.sttp.client3" %% "core"                        % "3.10.1" % Test
     )
 
     val logging: Seq[ModuleID] = Seq( //

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
     val logging: Seq[ModuleID] = Seq( //
       "com.outr" %% "scribe"            % "3.15.2",
       "com.outr" %% "scribe-cats"       % "3.15.2",
-      "com.outr" %% "scribe-slf4j"      % "3.15.0",
+      "com.outr" %% "scribe-slf4j"      % "3.15.2",
       "com.outr" %% "scribe-json-circe" % "3.15.2",
       "com.outr" %% "scribe-file"       % "3.15.2"
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
       "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server"         % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"            % "1.11.4",
       "com.softwaremill.sttp.tapir"   %% "tapir-opentelemetry-metrics" % "1.11.4",
-      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.4",
+      "com.softwaremill.sttp.tapir"   %% "tapir-iron"                  % "1.11.7",
       "com.softwaremill.sttp.tapir"   %% "tapir-openapi-docs"          % "1.11.4",
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml"          % "0.11.3",
       "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle"     % "1.11.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,7 +104,7 @@ object Dependencies {
     ) ++ tests ++ testContainers ++ migrationsRuntime.map(_ % Test)
 
     val fs2Rabbit: Seq[ModuleID] = Seq(
-      "dev.profunktor" %% "fs2-rabbit" % "5.2.0"
+      "dev.profunktor" %% "fs2-rabbit" % "5.3.0"
     ) ++ tests ++ testContainers
 
     val rediculous: Seq[ModuleID] = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.10.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.5.2")
 // documentation
 addSbtPlugin("com.github.sbt" % "sbt-unidoc"    % "0.5.0")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo" % "0.12.0")
-addSbtPlugin("com.github.sbt" % "sbt-dynver"    % "5.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver"    % "5.1.0")
 
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.46")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.5.2")
 
 // documentation
 addSbtPlugin("com.github.sbt" % "sbt-unidoc"    % "0.5.0")
-addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo" % "0.12.0")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"    % "5.1.0")
 
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.46")


### PR DESCRIPTION
- Update cats-collections-core from 0.9.8 to 0.9.9
- Update cats-effect from 3.5.4 to 3.5.6
- Update circe-yaml from 0.15.3 to 0.16.0
- Update client3:core from 3.9.8 to 3.10.1
- Update flyway-core from 10.18.0 to 11.0.0
- Update flyway-database-postgresql from 10.18.0 to 11.0.0
- Update fs2-rabbit from 5.2.0 to 5.3.0
- Update http4s-circe from 0.23.28 to 0.23.29
- Update http4s-core from 0.23.28 to 0.23.29
- Update http4s-dsl from 0.23.28 to 0.23.29
- Update http4s-netty-client from 0.5.19 to 0.5.21
- Update http4s-netty-server from 0.5.19 to 0.5.21
- Update otel4s from 0.8.1 to 0.11.1
- Update sbt from 1.10.2 to 1.10.4
- Update sbt-dynver from 5.0.1 to 5.1.0
- Update scodec-core from 2.2.2 to 2.3.2
- Update scala3-library from 3.3.3 to 3.3.4
- Update scribe from 3.15.0 to 3.15.2
- Update scribe-cats from 3.15.0 to 3.15.2
- Update scribe-file from 3.15.0 to 3.15.2
- Update scribe-json-circe from 3.15.0 to 3.15.2
- Update scribe-slf4j from 3.15.0 to 3.15.2
- Update skunk from 1.0.0-M7 eo 1.0.0-M8
- Update tapir-http4s-client from 1.11.4 to 1.11.9
- Update tapir-http4s-server from 1.11.4 to 1.11.9
- Update tapir-iron from 1.11.4 to 1.11.9
- Update tapir-json-circe from 1.11.4 to 1.11.9
- Update tapir-openapi-docs from 1.11.4 to 1.11.9
- Update tapir-opentelemetry-metrics from 1.11.4 to 1.11.9
- Update tapir-sttp-stub-server from 1.11.4 to 1.11.9
- Update tapir-swagger-ui-bundle from 1.11.4 to 1.11.9
